### PR TITLE
Set delay to an int to prevent TypeError

### DIFF
--- a/incept
+++ b/incept
@@ -92,7 +92,8 @@ def add_options(parser):
                       'successfully granted the host DMA before attacking. '
                       'If the attack fails, try to increase this value. '
                       'Default delay is {0} seconds.'.format(cfg.delay),
-                      default=cfg.delay)
+                      default=cfg.delay,
+                      type=int)
     parser.add_option('--sound',
                       action='store_true',
                       dest='sound',


### PR DESCRIPTION
On Python3.3 on Kali I was getting a TypeError when using the -d (delay) switch. Looks like it was being read as a string, and then treated as an int later on in the script.

```
# python3.3 incept unlock -d 30
<...>
[!] Warning: Something went dreadfully wrong, full stack trace below: unsupported operand type(s) for -: 'str' and 'int'

Traceback (most recent call last):
  File "incept", line 164, in main
    device, memsize = interface.initialize(opts, module)
  File "/root/inception/inception/interfaces/firewire.py", line 75, in initialize
    device = fw.getdevice(device_index, elapsed)
  File "/root/inception/inception/interfaces/firewire.py", line 260, in getdevice
    'or press Ctrl+C', seconds=self.delay - elapsed)
TypeError: unsupported operand type(s) for -: 'str' and 'int'
```
