### PR TITLE
Update some Windows 7 signatures

### DIFF
--- a/inception/modules/unlock.py
+++ b/inception/modules/unlock.py
@@ -209,7 +209,7 @@ targets = [
                 version=None,
                 md5=None,
                 tag=False,
-                offsets=[0x312, 0x6aa],
+                offsets=[0x312, 0x6aa, 0x642],
                 chunks=[
                     Chunk(
                         chunk=0x83f8100f85,

--- a/inception/modules/unlock.py
+++ b/inception/modules/unlock.py
@@ -170,7 +170,7 @@ targets = [
                 version=None,
                 md5=None,
                 tag=False,
-                offsets=[0x2a8, 0x2a1, 0x291, 0x321, 0xe59,0xe71,0xe09],
+                offsets=[0x2a8, 0x2a1, 0x291, 0x321, 0xe59,0xe71,0xe09,0xdf1],
                 chunks=[
                     Chunk(
                         chunk=0xc60f85,

--- a/inception/modules/unlock.py
+++ b/inception/modules/unlock.py
@@ -170,7 +170,7 @@ targets = [
                 version=None,
                 md5=None,
                 tag=False,
-                offsets=[0x2a8, 0x2a1, 0x291, 0x321, 0xe59,0xe71,0xe09,0xdf1],
+                offsets=[0x2a8, 0x2a1, 0x291, 0x321, 0xe59, 0xe71, 0xe09, 0xdf1],
                 chunks=[
                     Chunk(
                         chunk=0xc60f85,


### PR DESCRIPTION
Adds support for:

6.1.7601.23418
6.1.7601.23452
6.1.7601.23455

I have not verified these on an actual computer running these versions, only found the offset via analysis in IDA Pro.